### PR TITLE
Updates for compilation on modern systems

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -43,7 +43,7 @@ program's documentation), and then simply:
 
 cd src/
 ./configure
-make 
+make OCAMLPARAM=safe-string=0,_
 make install 
 
 By default the compilation scripts will try to use the ncurses, then the
@@ -52,7 +52,7 @@ following:
 
 cd src/
 ./configure --enable-interface=flat
-make
+make OCAMLPARAM=safe-string=0,_
 make install
 
 
@@ -65,7 +65,7 @@ also need MPI installed. To compile follow your MPI implementation
 recommendations, but a typical compilation would be:
 
 ./configure --enable-interface=flat --enable-mpi CC=mpicc
-make
+make OCAMLPARAM=safe-string=0,_
 make install
 
 Windows machines do not come with mpicc and setting this can be ignored. The

--- a/src/algn.c
+++ b/src/algn.c
@@ -3521,10 +3521,12 @@ algn_CAML_align_2d_bc (value *argv, int argn) {
 value 
 algn_CAML_align_3d (value s1, value s2, value s3, value c, value a, \
         value s1p, value s2p, value s3p, value uk) {
+    CAMLparam5(s1, s2, s3, c, a);
+    CAMLxparam4(s1p, s2p, s3p, uk);
     CAMLlocal1(res);
     res = algn_CAML_simple_3 (s1, s2, s3, c, a, uk);
     algn_CAML_backtrack_3d (s1, s2, s3, s1p, s2p, s3p, a, c);
-    return (res);
+    CAMLreturn(res);
 }
 
 value

--- a/src/camlpdf-0.3/zlibstubs.c
+++ b/src/camlpdf-0.3/zlibstubs.c
@@ -168,7 +168,7 @@ value camlzip_inflateEnd(value vzs)
 
 value camlzip_update_crc32(value crc, value buf, value pos, value len)
 {
-  return copy_int32(crc32((uint32) Int32_val(crc), 
+  return copy_int32(crc32((uint32_t) Int32_val(crc),
                           &Byte_u(buf, Long_val(pos)),
                           Long_val(len)));
 }

--- a/src/ptree.ml
+++ b/src/ptree.ml
@@ -2125,7 +2125,7 @@ let get_unique_fn get_tree get_cost datas =
     | x -> x
 
 
-let get_unique = get_unique_fn (fun x -> x.tree) (fun x -> get_cost `Adjusted x)
+let get_unique xx = get_unique_fn (fun x -> x.tree) (fun x -> get_cost `Adjusted x) xx
 
 
 (** [build_tree_with_names tree pd]


### PR DESCRIPTION
These series of patches make quick fixes to get poy5 running on modern versions of ocaml and gcc compilers.

The ocaml safe-strings hack is also included since I'm not interested in fixing the entire source tree up to modern standards, just enough to get it compiling.

There are other issues on macOS that I haven't addressed in this patch set.