### PR TITLE
Portability fixes for macOS

### DIFF
--- a/src/algn.c
+++ b/src/algn.c
@@ -20,8 +20,7 @@
 /* Alignment libray in C */
 
 #include <stdio.h>
-#include <malloc.h>
-#include <stdio.h>
+#include <stdlib.h>
 #include <limits.h>
 #define NDEBUG 1    //NDEBUG=1 also turns off assertions
 #include <assert.h>

--- a/src/algn.h
+++ b/src/algn.h
@@ -24,8 +24,7 @@
 #define ALGN_H 1
 
 #include <stdio.h>
-#include <malloc.h>
-#include <stdio.h>
+#include <stdlib.h>
 #include <assert.h>
 #include <caml/mlvalues.h>
 #include <caml/memory.h>

--- a/src/configure
+++ b/src/configure
@@ -4109,11 +4109,6 @@ else
 ac_fn_c_check_header_mongrel "$LINENO" ""$PATH_PREFIX/include/malloc/malloc.h"" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   CFLAGS="-I $PATH_PREFIX/include/malloc/ $CFLAGS"
-else
-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "Could not find malloc.h
-See \`config.log' for more details" "$LINENO" 5; }
 fi
 
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -399,12 +399,6 @@ AS_IF([test $USEINTERFACE = "readline"],
                 [USEINTERFACE="flat"])])],
         [])
 
-# Check for malloc, if not there, this is most likely a Mac OS X.
-AC_CHECK_HEADER(malloc.h,[],
-                [AC_CHECK_HEADER("$PATH_PREFIX/include/malloc/malloc.h",
-                                [CFLAGS="-I $PATH_PREFIX/include/malloc/ $CFLAGS"],
-                                [AC_MSG_FAILURE([Could not find malloc.h])])])
-
 AC_CHECK_PROGS([OCAML],[ocaml])
 AC_CHECK_PROGS([OCAMLC], [ocamlc.opt ocamlc])
 AC_CHECK_PROGS([OCAMLYACC], [ocamlyacc.opt ocamlyacc])

--- a/src/gamma.c
+++ b/src/gamma.c
@@ -20,7 +20,6 @@
 #include <stdlib.h> /* malloc, calloc, srand, RAND_MAX */
 #include <string.h> /* memcpy, memset */
 #include <assert.h>
-#include <malloc.h>
 
 #include "config.h" //defines if likelihood, use_.., et cetera
 #include <math.h>   //log,exp

--- a/src/newkkonen.c
+++ b/src/newkkonen.c
@@ -18,7 +18,7 @@
 \* USA                                                                        */
 
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <limits.h>
 #include <string.h>
 #include <assert.h>

--- a/src/nonaddCSc.c
+++ b/src/nonaddCSc.c
@@ -188,7 +188,7 @@ typedef vector CHARTYPE vect;
  * length;  and they can operate on two longs, four shorts, or eight chars. */
 
 #include <xmmintrin.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 /* in bits */
 #define VECT_SIZE 64

--- a/src/sankoff.c
+++ b/src/sankoff.c
@@ -18,7 +18,7 @@
 /* USA                                                                        */
 
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <limits.h>
 #include <string.h>
 #include <assert.h>


### PR DESCRIPTION
This pull request removes Linux-isms, specifically `include <malloc.h>` which is non-standard and is not present on macOS. All memory allocation functions are in `stdlib.h` as defined in the C89 standard.

Also patches `configure` and `configure.ac` to remove specific checks for this file. `autoreconf` should probably be rerun and a new `configure` commited after this is merged.